### PR TITLE
[OK-59642] Add custom topbar plugin

### DIFF
--- a/dev-helpers/dev-helper-initializer.js
+++ b/dev-helpers/dev-helper-initializer.js
@@ -5,7 +5,10 @@ window.onload = function() {
   window["OhBundle"] = window["oh-bundle"]
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "https://petstore.swagger.io/v2/swagger.json",
+    urlsFrom: [
+      { name: "petstore", url: "./specs.json" },
+      { name: "dev", url: "./examples/specs.dev.json" },
+    ],
     dom_id: "#swagger-ui",
     presets: [
       SwaggerUIBundle.presets.apis,
@@ -13,7 +16,8 @@ window.onload = function() {
     ],
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl,
-      OhBundle.plugins.OperationPermissionsPlugin
+      OhBundle.plugins.OperationPermissionsPlugin,
+      OhBundle.plugins.TopBarWithEnvSwitchingPlugin
     ],
     // requestSnippetsEnabled: true,
     layout: "StandaloneLayout"

--- a/dev-helpers/specs.json
+++ b/dev-helpers/specs.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "Petstore API",
+    "url": "https://petstore3.swagger.io/api/v3/openapi.json"
+  }
+]

--- a/src/oh/index.js
+++ b/src/oh/index.js
@@ -1,8 +1,10 @@
 import OperationPermissionsPlugin from "./plugins/operation-permissions"
+import TopBarWithEnvSwitchingPlugin from "./plugins/top-bar-with-env-switching"
 
 const Oh = {
   plugins: {
     OperationPermissionsPlugin,
+    TopBarWithEnvSwitchingPlugin,
   },
 }
 

--- a/src/oh/plugins/top-bar-with-env-switching/components/TopBarWithEnvSwitching.jsx
+++ b/src/oh/plugins/top-bar-with-env-switching/components/TopBarWithEnvSwitching.jsx
@@ -1,0 +1,181 @@
+/**
+ * This component intentionally mirrors and extends the default Swagger UI `TopBar`
+ * (src/standalone/plugins/top-bar/components/TopBar.jsx).
+ *
+ * Key divergences from upstream TopBar:
+ *   - Specs are loaded dynamically at runtime by fetching the URL provided per-env
+ *     via the `urlsFrom` config option, rather than being passed in via `urls` config.
+ *   - An environment switcher (buttons) is rendered alongside the spec dropdown,
+ *     driven by `urlsFrom` entries. Switching envs triggers a full page reload.
+ *   - The free-text URL input fallback is intentionally omitted.
+ *
+ */
+import React from "react"
+import PropTypes from "prop-types"
+
+import { parseSearch, serializeSearch } from "core/utils"
+
+const buildSearchUrl = (updates, removals = []) => {
+  const pageUrl = `${window.location.protocol}//${window.location.host}${window.location.pathname}`
+  const search = parseSearch()
+  Object.assign(search, updates)
+  removals.forEach((key) => delete search[key])
+  return `${pageUrl}?${serializeSearch(search)}`
+}
+
+const replaceSearchParams = (updates, removals = []) => {
+  if (window && window.history && window.history.replaceState) {
+    window.history.replaceState(null, "", buildSearchUrl(updates, removals))
+  }
+}
+
+class TopBarWithEnvSwitching extends React.Component {
+  constructor(props, context) {
+    super(props, context)
+
+    this.state = {
+      selectedIndex: 0,
+      selectedEnv: parseSearch()["urls.selectedEnv"],
+      specs: [],
+    }
+  }
+
+  flushAuthData() {
+    const { persistAuthorization } = this.props.getConfigs()
+    if (persistAuthorization) {
+      return
+    }
+    this.props.authActions.restoreAuthorization({ authorized: {} })
+  }
+
+  loadSpec = (url) => {
+    this.flushAuthData()
+    this.props.specActions.updateUrl(url)
+    this.props.specActions.download(url)
+  }
+
+  onUrlSelect = (e) => {
+    const url = e.target.value || e.target.href
+    this.loadSpec(url)
+    this.setSelectedUrl(url)
+    e.preventDefault()
+  }
+
+  setSelectedUrl = (selectedUrl) => {
+    this.state.specs.forEach((spec, i) => {
+      if (spec.url === selectedUrl) {
+        this.setState({ selectedIndex: i })
+        replaceSearchParams({ "urls.primaryName": spec.name })
+      }
+    })
+  }
+
+  async componentDidMount() {
+    const { urlsFrom } = this.props.getConfigs()
+
+    if (!urlsFrom || !urlsFrom.length) {
+      return
+    }
+
+    const search = parseSearch()
+    const selectedEnv = search["urls.selectedEnv"] || urlsFrom[0].name
+
+    if (!search["urls.selectedEnv"]) {
+      replaceSearchParams({ "urls.selectedEnv": selectedEnv })
+    }
+
+    this.setState({ selectedEnv })
+
+    const envEntry = urlsFrom.find((entry) => entry.name === selectedEnv) || urlsFrom[0]
+
+    try {
+      const response = await fetch(envEntry.url)
+      const specs = await response.json()
+
+      const primaryName = search["urls.primaryName"]
+      const matchIndex = primaryName ? specs.findIndex((spec) => spec.name === primaryName) : -1
+      const selectedIndex = matchIndex >= 0 ? matchIndex : 0
+
+      this.setState({ specs, selectedIndex })
+      this.loadSpec(specs[selectedIndex].url)
+    } catch (e) {
+      console.error("TopBarWithEnvSwitching: failed to load specs for environment:", selectedEnv, e)
+    }
+  }
+
+  switchEnv = (env) => {
+    window.location.href = buildSearchUrl(
+      { "urls.selectedEnv": env },
+      ["urls.primaryName"]
+    )
+  }
+
+  render() {
+    const { getComponent, specSelectors, getConfigs } = this.props
+    const { selectedEnv, specs, selectedIndex } = this.state
+
+    const Button = getComponent("Button")
+    const Link = getComponent("Link")
+    const Logo = getComponent("Logo")
+    const DarkModeToggle = getComponent("DarkModeToggle")
+
+    const isLoading = specSelectors.loadingStatus() === "loading"
+
+    const { urlsFrom } = getConfigs()
+
+    return (
+      <div className="topbar">
+        <div className="wrapper">
+          <div className="topbar-wrapper">
+            <Link>
+              <Logo />
+            </Link>
+            {specs.length ? (
+              <form className="download-url-wrapper">
+                <label className="select-label" htmlFor="select">
+                  <span>Select a definition</span>
+                  <select
+                    id="select"
+                    disabled={isLoading}
+                    onChange={this.onUrlSelect}
+                    value={specs[selectedIndex] ? specs[selectedIndex].url : ""}
+                  >
+                    {specs.map((link) => (
+                      <option key={link.url} value={link.url}>
+                        {link.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </form>
+            ) : null}
+            {urlsFrom && urlsFrom.length ? (
+              <div className="env-switcher">
+                {urlsFrom.map((entry) => (
+                  <Button
+                    key={entry.name}
+                    className={`env-switcher__btn${entry.name === selectedEnv ? " env-switcher__btn--active" : ""}`}
+                    onClick={() => this.switchEnv(entry.name)}
+                  >
+                    {entry.name.toUpperCase()}
+                  </Button>
+                ))}
+              </div>
+            ) : null}
+            <DarkModeToggle />
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+TopBarWithEnvSwitching.propTypes = {
+  specSelectors: PropTypes.object.isRequired,
+  specActions: PropTypes.object.isRequired,
+  authActions: PropTypes.object.isRequired,
+  getComponent: PropTypes.func.isRequired,
+  getConfigs: PropTypes.func.isRequired,
+}
+
+export default TopBarWithEnvSwitching

--- a/src/oh/plugins/top-bar-with-env-switching/index.js
+++ b/src/oh/plugins/top-bar-with-env-switching/index.js
@@ -1,0 +1,10 @@
+/**
+ * @prettier
+ */
+import TopBarWithEnvSwitching from "./components/TopBarWithEnvSwitching"
+
+const TopBarWithEnvSwitchingPlugin = () => ({
+  components: { Topbar: TopBarWithEnvSwitching },
+})
+
+export default TopBarWithEnvSwitchingPlugin

--- a/src/style/_top-bar-with-env-switching.scss
+++ b/src/style/_top-bar-with-env-switching.scss
@@ -1,0 +1,35 @@
+@use "variables" as *;
+
+.topbar {
+  .env-switcher {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: 10px;
+
+    .env-switcher__btn {
+      font-size: 13px;
+      font-weight: bold;
+      padding: 4px 10px;
+      border: 2px solid rgba(255, 255, 255, 0.3);
+      border-radius: 4px;
+      background: transparent;
+      color: rgba(255, 255, 255, 0.6);
+      cursor: pointer;
+      transition: all 0.15s ease;
+      white-space: nowrap;
+
+      &:hover:not(.env-switcher__btn--active) {
+        border-color: rgba(255, 255, 255, 0.6);
+        color: $topbar-link-font-color;
+      }
+
+      &.env-switcher__btn--active {
+        background: $apple-green;
+        border-color: $apple-green;
+        color: $topbar-link-font-color;
+        cursor: default;
+      }
+    }
+  }
+}

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -24,6 +24,7 @@
   @include meta.load-css("split-pane-mode");
   @include meta.load-css("markdown");
   @include meta.load-css("operation-permissions");
+  @include meta.load-css("top-bar-with-env-switching");
   @include meta.load-css("../core/plugins/json-schema-2020-12/components/all");
   @include meta.load-css("../core/plugins/oas31/components/all");
 }


### PR DESCRIPTION
Add a custom topbar plugin which is pretty much the default `TopBar` component but with buttons for changing the set of `urls`. This can be used for changing between e.g. `dev` / `stage` / `prod` specs.

Usage:
```jsonc
// ./specs.json
[
  { "name": "Petstore API", "url": "https://petstore3.swagger.io/api/v3/openapi.json" }
]
```
```jsonc
// ./examples/specs.dev.json
[
  { "name": "[dev] Overhaul Platform API", "url": "./examples/specs/v3.dev.json" },
  { "name": "[dev] Overhaul Internal Services API", "url": "./examples/specs/internal.dev.json" },
  { "name": "[dev] Overhaul Platform API — V2", "url": "./examples/specs/v2.dev.json" },
  { "name": "[dev] Overhaul Webhook Events", "url": "./examples/specs/webhooks.dev.json" }
]
```
```javascript
// dev-helper-initializer.js
window.onload = function() {
  window["SwaggerUIBundle"] = window["swagger-ui-bundle"]
  window["SwaggerUIStandalonePreset"] = window["swagger-ui-standalone-preset"]
  window["OhBundle"] = window["oh-bundle"]
  // Build a system
  const ui = SwaggerUIBundle({
    urlsFrom: [
      { name: "petstore", url: "./specs.json" },
      { name: "dev", url: "./examples/specs.dev.json" },
    ],
    dom_id: "#swagger-ui",
    presets: [
      SwaggerUIBundle.presets.apis,
      SwaggerUIStandalonePreset
    ],
    plugins: [
      OhBundle.plugins.TopBarWithEnvSwitchingPlugin
    ],
    // requestSnippetsEnabled: true,
    layout: "StandaloneLayout"
  })

  window.ui = ui
}
```

Demo:

https://github.com/user-attachments/assets/3cf8e4ba-aad2-411a-a7fb-481975d14d8a

