### PR TITLE
[~] Add OAuth2-related plugins

### DIFF
--- a/src/oh/index.js
+++ b/src/oh/index.js
@@ -1,10 +1,14 @@
+import ClearStaleOauth2CodePlugin from "./plugins/clear-stale-oauth2-code"
 import OperationPermissionsPlugin from "./plugins/operation-permissions"
 import TopBarWithEnvSwitchingPlugin from "./plugins/top-bar-with-env-switching"
+import UseAndPersistOidcLoginHintPlugin from "./plugins/use-and-persist-oidc-login-hint"
 
 const Oh = {
   plugins: {
+    ClearStaleOauth2CodePlugin,
     OperationPermissionsPlugin,
     TopBarWithEnvSwitchingPlugin,
+    UseAndPersistOidcLoginHintPlugin,
   },
 }
 

--- a/src/oh/plugins/clear-stale-oauth2-code/index.js
+++ b/src/oh/plugins/clear-stale-oauth2-code/index.js
@@ -1,0 +1,16 @@
+export default () => ({
+  statePlugins: {
+    auth: {
+      wrapActions: {
+        authPopup: (original) => (url, oauth2Data) => {
+          if (oauth2Data.auth) {
+            // Clear stale code from previous session
+            // see: https://github.com/swagger-api/swagger-ui/pull/10693
+            delete oauth2Data.auth.code
+          }
+          return original(url, oauth2Data)
+        }
+      }
+    }
+  }
+})

--- a/src/oh/plugins/use-and-persist-oidc-login-hint/index.js
+++ b/src/oh/plugins/use-and-persist-oidc-login-hint/index.js
@@ -1,0 +1,93 @@
+export default (system) => {
+  const getOidcSchemes = () =>
+    system.specSelectors.securityDefinitions()?.filter((d) => d.get("type") === "openIdConnect" && d.get("openIdConnectUrl"))
+
+  const getLoginHints = () => {
+    try {
+      return JSON.parse(localStorage.getItem("login_hints")) || {}
+    } catch (e) {
+      console.error("OidcLoginHintPlugin: failed to parse login_hints from localStorage", e)
+      return {}
+    }
+  }
+
+  // Store the login hints in localStorage, so they persist across page
+  const saveLoginHint = (oidcUrl, preferredUsername) => {
+    const hints = getLoginHints()
+    hints[oidcUrl] = preferredUsername
+    localStorage.setItem("login_hints", JSON.stringify(hints))
+  }
+
+  // Re-initialize OAuth config, so following logins to the same IDP will
+  // use the login_hint from localStorage
+  const applyLoginHint = (oidcUrl) => {
+    const hint = getLoginHints()[oidcUrl]
+    if (hint) {
+      const currentConfig = system.authSelectors.getConfigs() || {}
+      const { additionalQueryStringParams } = currentConfig
+      system.authActions.configureAuth({
+        ...currentConfig,
+        additionalQueryStringParams: { ...additionalQueryStringParams, login_hint: hint }
+      })
+    }
+  }
+
+  const handleResponse = (response) => {
+    if (!response.url || !response.body || response.status >= 400) {
+      return response
+    }
+
+    const oidcSchemes = getOidcSchemes()
+    if (!oidcSchemes) return response
+
+    // When resolving the OpenID Connect URLs, if we have a login hint for that
+    // identity provider (from a previous login), we can add it to the OAuth
+    // config so that the user doesn't have to re-enter their username.
+    if (oidcSchemes.some((d) => d.get("openIdConnectUrl") === response.url)) {
+      applyLoginHint(response.url)
+      return response
+    }
+
+    // If the response is from a token endpoint, we can extract the preferred_username
+    // from the id_token and store it in localStorage for future logins.
+    const securityScheme = oidcSchemes.find((d) => d.getIn(["openIdConnectData", "token_endpoint"]) === response.url)
+    if (securityScheme) {
+      try {
+        const claims = JSON.parse(atob(response.body.id_token.split(".")[1]))
+        if (claims.preferred_username) {
+          const oidcUrl = securityScheme.get("openIdConnectUrl")
+          saveLoginHint(oidcUrl, claims.preferred_username)
+          applyLoginHint(oidcUrl)
+        }
+      } catch (e) {
+        console.error("OidcLoginHintPlugin: failed to parse id_token", e)
+      }
+    }
+
+    return response
+  }
+
+  return {
+    statePlugins: {
+      configs: {
+        wrapActions: {
+          loaded: (original) => (...args) => {
+            original(...args)
+            // Wrap fn.fetch directly — configsActions.update can't store
+            // functions because the UPDATE_CONFIGS reducer uses fromJS(),
+            // which silently drops non-serializable values like functions.
+            const originalFetch = system.fn.fetch
+            system.fn.fetch = (req) => {
+              const responseInterceptor = req.responseInterceptor
+              req.responseInterceptor = (res) => {
+                const intercepted = responseInterceptor ? responseInterceptor(res) : res
+                return handleResponse(intercepted)
+              }
+              return originalFetch(req)
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION


### Description
- add plugin to clear stale `oauth2` from past sessions (bug upstream, see: swagger-api/swagger-ui#10693)
- add plugin to get `preferred_username` from id_token and use as login_hint query parameter on OAuth2 authorize requests



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Use the magic "Fixes #1234" format, so the issues are -->
<!--- automatically closed when this PR is merged. -->



### How Has This Been Tested?
<!--- Please describe in detail how you manually tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



### Screenshots (if appropriate):



## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### My PR contains... 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] No code changes (`src/` is unmodified: changes to documentation, CI, metadata, etc.)
- [ ] Dependency changes (any modification to dependencies in `package.json`)
- [ ] Bug fixes (non-breaking change which fixes an issue)
- [ ] Improvements (misc. changes to existing features)
- [ ] Features (non-breaking change which adds functionality)

### My changes...
- [ ] are breaking changes to a public API (config options, System API, major UI change, etc).
- [ ] are breaking changes to a private API (Redux, component props, utility functions, etc.).
- [ ] are breaking changes to a developer API (npm script behavior changes, new dev system dependencies, etc).
- [ ] are not breaking changes.

### Documentation
- [ ] My changes do not require a change to the project documentation.
- [ ] My changes require a change to the project documentation.
- [ ] If yes to above: I have updated the documentation accordingly.

### Automated tests
- [ ] My changes can not or do not need to be tested.
- [ ] My changes can and should be tested by unit and/or integration tests.
- [ ] If yes to above: I have added tests to cover my changes.
- [ ] If yes to above: I have taken care to cover edge cases in my tests.
- [ ] All new and existing tests passed.
